### PR TITLE
Switch to marked since node-markdown is depracated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
+'use strict';
+
 var fs = require('fs');
-var md = require('node-markdown').Markdown;
+var md = require('marked');
 
 /**
  * Middleware for creating dynamic routes by reading a directory of md files
@@ -24,7 +26,7 @@ var markdownRouter = function(filePath, template) {
      * @return Boolean
      */
     function isDev() {
-        return process.env.NODE_ENV != 'production';
+        return process.env.NODE_ENV !== 'production';
     }
 
     /**
@@ -158,7 +160,7 @@ var markdownRouter = function(filePath, template) {
                 markdown: md(markdown.replace(configRegex, ''))
             });
         });
-    }
-}
+    };
+};
 
 module.exports = markdownRouter;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "iamstuartwilson",
   "license": "MIT",
   "dependencies": {
-    "node-markdown": "^0.1.1"
+    "marked": "^0.3.5"
   },
   "devDependencies": {
     "express": "^4.10.6",


### PR DESCRIPTION
- Switch to marked (supports ids when using h1-h5 and markdown tables)
- Added `'use strict';`
- Fixed `jslint` warnings.

Thanks for this useful module.
